### PR TITLE
Support Travis with latest JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,7 +13,7 @@ dist: bionic
 
 jdk:
   - oraclejdk11
-  - oraclejdk14
+  - openjdk-ea
 
 cache:
   directories:


### PR DESCRIPTION
It works by default (API and Spec) with JDK 17.